### PR TITLE
fix: workaround for installing bbr

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -277,7 +277,8 @@ migrate_v2_ui() {
 }
 
 install_bbr() {
-    bash <(curl -L -s https://raw.githubusercontent.com/sprov065/blog/master/bbr.sh)
+    # temporary workaround for installing bbr
+    bash <(curl -L -s https://raw.githubusercontent.com/teddysun/across/master/bbr.sh)
     echo ""
     before_show_menu
 }


### PR DESCRIPTION
The former link for installing bbr is not found anymore (sprov065/blog).

The workaround is using [this script](https://raw.githubusercontent.com/teddysun/across/master/bbr.sh) to install the latest version of BBR.

More details can be founded in the script, I only tested this script on my AWS EC2 machine with ubuntu 20, the compability cannot be sure until more tests reported from users. (I assume this script would work on most machines)

### Related issues
 #65 

### Feature request
Multilingual support - https://github.com/vaxilu/x-ui/issues/24#issuecomment-905308362